### PR TITLE
Fixing mingw

### DIFF
--- a/lib/sys_time.in.h
+++ b/lib/sys_time.in.h
@@ -65,7 +65,7 @@
 extern "C" {
 #endif
 
-#if !@HAVE_STRUCT_TIMEVAL@ || @REPLACE_STRUCT_TIMEVAL@
+#if !@HAVE_STRUCT_TIMEVAL@ || (@REPLACE_STRUCT_TIMEVAL@ && !defined _WIN32)
 
 # if @REPLACE_STRUCT_TIMEVAL@
 #  define timeval rpl_timeval

--- a/libguile/lightening/lightening/x86-cpu.c
+++ b/libguile/lightening/lightening/x86-cpu.c
@@ -122,6 +122,16 @@
   M(g,   G,   0xf)     \
   M(nle, NLE, 0xf)     \
   /* EOL */
+#ifndef ffs
+#include <intrin.h> // For Windows intrinsics
+static inline int ffs(int i) {
+    unsigned long index;
+    if (_BitScanForward(&index, (unsigned long)i)) {
+        return (int)index + 1; // _BitScanForward returns 0-based index, ffs is 1-based
+    }
+    return 0; // Return 0 if no bits are set, per ffs behavior
+}
+#endif
 
 enum x86_cc
 {

--- a/libguile/posix.c
+++ b/libguile/posix.c
@@ -1176,7 +1176,11 @@ SCM_DEFINE (scm_execl, "execl", 1, 0, 1,
 
   exec_argv = scm_i_allocate_string_pointers (args);
 
+#ifdef __MINGW32__
+  execv (exec_file, (const char *const *)exec_argv);
+#else
   execv (exec_file, exec_argv);
+#endif
   SCM_SYSERROR;
 
   /* not reached.  */
@@ -1204,8 +1208,12 @@ SCM_DEFINE (scm_execlp, "execlp", 1, 0, 1,
   scm_dynwind_free (exec_file);
 
   exec_argv = scm_i_allocate_string_pointers (args);
+#ifdef __MINGW32__
+  execv (exec_file, (const char *const *)exec_argv);
+#else
+  execv (exec_file, exec_argv);
+#endif
 
-  execvp (exec_file, exec_argv);
   SCM_SYSERROR;
 
   /* not reached.  */
@@ -1223,10 +1231,19 @@ SCM_DEFINE (scm_execle, "execle", 2, 0, 1,
 	    "Similar to @code{execl}, but the environment of the new process is\n"
 	    "specified by @var{env}, which must be a list of strings as returned by the\n"
 	    "@code{environ} procedure.\n\n"
-	    "This procedure is currently implemented using the @code{execve} system\n"
-	    "call, but we call it @code{execle} because of its Scheme calling interface.")
+#ifdef __MINGW32__
+            "This function is not fully supported on Windows.\n"
+            "It currently raises an error indicating unimplemented functionality.")
+#else
+            "This procedure is currently implemented using the @code{execve} system\n"
+            "call, but we call it @code{execle} because of its Scheme calling interface.")
+#endif
 #define FUNC_NAME s_scm_execle
 {
+#ifdef __MINGW32__
+  SCM_MISC_ERROR ("execle is not implemented on Windows", SCM_EOL);
+  return SCM_BOOL_F;
+#else
   char **exec_argv;
   char **exec_env;
   char *exec_file;
@@ -1245,6 +1262,7 @@ SCM_DEFINE (scm_execle, "execle", 2, 0, 1,
   /* not reached.  */
   scm_dynwind_end ();
   return SCM_BOOL_F;
+#endif
 }
 #undef FUNC_NAME
 

--- a/libguile/stime.c
+++ b/libguile/stime.c
@@ -44,6 +44,10 @@
 #  include <config.h>
 #endif
 
+#ifdef _WIN32
+#include <sys/time.h>  
+#endif
+
 #include <errno.h>
 #include <stdio.h>
 #include <strftime.h>

--- a/libguile/syscalls.h
+++ b/libguile/syscalls.h
@@ -1,6 +1,5 @@
 #ifndef SCM_SYSCALLS_H
 #define SCM_SYSCALLS_H
-
 /* Copyright 1995-1996,2000-2002,2006,2008-2011,2013-2014,2018
      Free Software Foundation, Inc.
 
@@ -20,10 +19,10 @@
    License along with Guile.  If not, see
    <https://www.gnu.org/licenses/>.  */
 
-
 
 /* ASYNC_TICK after finding EINTR in order to handle pending signals, if
    any. See comment in scm_syserror. */
+#include "libguile/async.h" 
 #define SCM_SYSCALL(line)			\
   do						\
     {						\
@@ -38,7 +37,6 @@
   while (errno == EINTR)
 
 
-
 
 #if defined GUILE_USE_64_CALLS && GUILE_USE_64_CALLS && defined(HAVE_STAT64)
 #define CHOOSE_LARGEFILE(foo,foo64)     foo64

--- a/libguile/vm.c
+++ b/libguile/vm.c
@@ -20,6 +20,10 @@
 #if HAVE_CONFIG_H
 #  include <config.h>
 #endif
+#ifdef _WIN32
+#include <winsock2.h>
+#include <windows.h>
+#endif
 
 #include <alignof.h>
 #include <alloca.h>
@@ -596,7 +600,13 @@ scm_i_vm_prepare_stack (struct scm_vm *vp)
      Guile.  */
   if (page_size == 0)
     {
-      page_size = getpagesize ();
+#ifdef _WIN32
+      SYSTEM_INFO si;
+      GetSystemInfo(&si);
+      page_size = si.dwPageSize;
+#else
+      page_size = getpagesize();
+#endif
       /* page_size should be a power of two.  */
       if (page_size & (page_size - 1))
         abort ();


### PR DESCRIPTION
I fixed the errors before you did, and I kinda like using the getpage function native to win32 rather than hardcoding it. There is guile.exe DOES build.

however it does not boot yet
```
topkek@win11 UCRT64 ~/git/guile/libguile
# GUILE_AUTO_COMPILE=0 ../meta/build-env guild snarf-check-and-output-texi
Pre-boot error; key: wrong-number-of-args, args: (#f "Wrong number of arguments to ~A" (#<program 19a01c96820 19a0115e398>) #f)

```


or
```
topkek@win11 UCRT64 ~/git/guile/libguile
# ./guile
Pre-boot error; key: misc-error, args: ("primitive-load-path" "Unable to find file ~S in load path" ("ice-9/boot-9") #f)

```

